### PR TITLE
Fix: Add header for GCC 13

### DIFF
--- a/cuda_rasterizer/rasterizer_impl.h
+++ b/cuda_rasterizer/rasterizer_impl.h
@@ -15,6 +15,7 @@
 #include <vector>
 #include "rasterizer.h"
 #include <cuda_runtime_api.h>
+#include <cstdint>
 
 namespace CudaRasterizer
 {


### PR DESCRIPTION
[GCC 13 does not implicitly include cstdint](https://gcc.gnu.org/gcc-13/porting_to.html)

GCC 13 开始需要显式包含 `cstdint`，否则编译时会报错：

```
error: namespace "std" has no member "uintptr_t"
```

This PR fixed this issue.

Ref: https://github.com/graphdeco-inria/gaussian-splatting/issues/788

PS. Your repo of great work is used by [ComfyUI-3D-Pack](https://github.com/MrForExample/ComfyUI-3D-Pack) and that's why I'm here.